### PR TITLE
Added thiserror for improved error handling and removed no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [dependencies]
 defmt = { version = "0.3.8", optional = true }
 scroll = { version = "0.12.0", default-features = false }
+thiserror = "1.0.65"
 
 [features]
 debug = []


### PR DESCRIPTION
This pull request introduces thiserror to simplify and improve error handling in the library and removes no_std for broader compatibility with standard Rust environments.

Changes include:

Error Handling with thiserror: Replaced custom error handling with thiserror, providing clear, concise error messages and aligning with idiomatic Rust practices.
Removed no_std: Dropped no_std configuration, making the library more compatible with standard Rust projects, as no_std is often too specific to embedded environments.
Simplified API: Streamlined the API by removing scroll dependency and replacing Deref and DerefMut with a standard as_bytes() method for safer internal access.
These changes simplify the codebase, reduce dependencies, and improve the library’s usability in non-embedded projects.